### PR TITLE
add initial setup.py without requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="gopher",
+    version="0.1.0",
+    packages=find_packages(),
+    python_requires=">=3.7",
+)


### PR DESCRIPTION
This commit adds a minimal setup.py file to install the gopher package.

However, I cannot find some of the imported packages. Like `explain` and
`embed` in `add_motifs_GIA.py`. Importing `gopher.add_motifs_GIA` will
fail.